### PR TITLE
Snappyimg: fix unreliable restoring of error handler in packHex()

### DIFF
--- a/src/Snappyimg/Snappyimg.php
+++ b/src/Snappyimg/Snappyimg.php
@@ -76,15 +76,12 @@ final class Snappyimg
             throw InvalidCredentialsException::appToken($hexString);
         };
 
-        $previousHandler = NULL;
         try {
-            $previousHandler = set_error_handler($handler);
+            set_error_handler($handler);
             return pack("H*" , $hexString);
 
         } finally {
-            if ($previousHandler) {
-                set_error_handler($previousHandler);
-            }
+            restore_error_handler();
         }
     }
 


### PR DESCRIPTION
It worked only when some error handler was previously defined. 
Which is not always the case.